### PR TITLE
Add generic preference results support to backend

### DIFF
--- a/controllers/ceoTasks.go
+++ b/controllers/ceoTasks.go
@@ -14,20 +14,20 @@ import (
 )
 
 // Struct to accept the keys from the client.
-type NewCEOData struct {
+type newCEOData struct {
 	PublicKey  string `json:"pubkey"`
 	PrivateKey string `json:"privkey"`
 }
 
 // Struct to return candidates' data to the CEO.
-type CandidateData struct {
+type candidateData struct {
 	Name       string
 	Roll       string
 	PostID     string
 	PrivateKey string
 }
 
-type CandidateResult struct {
+type candidateResult struct {
 	Roll      string   `json:"roll"`
 	Name      string   `json:"name"`
 	Count     int32    `json:"count"`
@@ -35,15 +35,15 @@ type CandidateResult struct {
 	Status    string   `json:"status"`
 }
 
-type PostResult struct {
+type postResult struct {
 	ID         string            `json:"postid"`
 	Name       string            `json:"postname"`
 	Resolved   bool              `json:"resolved"`
-	Candidates []CandidateResult `json:"candidates"`
+	Candidates []candidateResult `json:"candidates"`
 }
 
-type ResultData struct {
-	Posts []PostResult `json:"posts"`
+type resultData struct {
+	Posts []postResult `json:"posts"`
 }
 
 // API handler to send verification mail to CEO.
@@ -183,10 +183,10 @@ func FetchCandidates(c *gin.Context) {
 		c.String(http.StatusInternalServerError, "Error while fetching candidates.")
 	}
 
-	var data []CandidateData
+	var data []candidateData
 	for _, candidate := range candidates {
 		if isCandidateStillInRace(candidate.PostID, candidate.Username) {
-			data = append(data, CandidateData{
+			data = append(data, candidateData{
 				Name:       candidate.Name,
 				Roll:       candidate.Roll,
 				PostID:     candidate.PostID,
@@ -236,7 +236,7 @@ func StartVoting(c *gin.Context) {
 		c.String(http.StatusInternalServerError, "CEO not yet assigned.")
 		return
 	}
-	newData := NewCEOData{}
+	newData := newCEOData{}
 	err = c.BindJSON(&newData)
 	if err != nil {
 		log.Println("[ERROR] CEO data JSON did not bind to struct: ", err.Error())
@@ -344,7 +344,7 @@ func SubmitSingleVoteResults(c *gin.Context) {
 		return
 	}
 
-	var results ResultData
+	var results resultData
 	err = c.BindJSON(&results)
 	if err != nil {
 		log.Println("[ERROR] SingleVoteResults JSON did not bind to struct: ", err.Error())
@@ -366,7 +366,7 @@ func SubmitSingleVoteResults(c *gin.Context) {
 			ID:   postId,
 			Name: post.Name,
 		}
-		var candidateResults []models.CandidateResult
+		var candidateResults []models.SingleVoteCandidateResult
 		for _, candidate := range post.Candidates {
 			tmpBallotId := models.UsedBallotID{
 				Name: candidate.Name,
@@ -376,7 +376,7 @@ func SubmitSingleVoteResults(c *gin.Context) {
 				tmpBallotId.BallotString = ballotString
 				ballotIds = append(ballotIds, tmpBallotId)
 			}
-			candidateResult := models.CandidateResult{
+			candidateResult := models.SingleVoteCandidateResult{
 				Name:   candidate.Name,
 				Roll:   candidate.Roll,
 				Count:  candidate.Count,

--- a/controllers/electionTasks.go
+++ b/controllers/electionTasks.go
@@ -92,3 +92,14 @@ func GetSingleVoteResults(c *gin.Context) {
 
 	c.JSON(http.StatusOK, result)
 }
+
+func GetResults(c *gin.Context) {
+	result, err := ElectionDb.FindAllResults()
+	if err != nil {
+		log.Println("[ERROR] Could not get results from db: ", err.Error())
+		c.String(http.StatusInternalServerError, "Database Error")
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}

--- a/db/mongo.go
+++ b/db/mongo.go
@@ -23,6 +23,7 @@ type ElectionDatabase struct {
 	PostsCollection             *mongo.Collection
 	BallotIdsCollection         *mongo.Collection
 	SingleVoteResultsCollection *mongo.Collection
+	ResultsCollection           *mongo.Collection
 	StudentsCollection          *mongo.Collection
 	VotesCollection             *mongo.Collection
 }
@@ -65,6 +66,7 @@ func ConnectToDatabase() (ElectionDatabase, error) {
 		electionDb.VotesCollection = mongoClient.Database(config.MongoDbName).Collection("votes")
 		electionDb.StudentsCollection = mongoClient.Database(config.MongoDbName).Collection("students")
 		electionDb.SingleVoteResultsCollection = mongoClient.Database(config.MongoDbName).Collection("singlevoteresults")
+		electionDb.ResultsCollection = mongoClient.Database(config.MongoDbName).Collection("results")
 		electionDb.BallotIdsCollection = mongoClient.Database(config.MongoDbName).Collection("ballotids")
 	}
 

--- a/db/result.go
+++ b/db/result.go
@@ -1,28 +1,31 @@
 package db
 
 import (
+	"context"
+
+	"go.mongodb.org/mongo-driver/bson"
+
 	"github.com/dryairship/online-election-manager/models"
 )
 
-// Function to insert a new result into the database.
-// TODO
 func (db ElectionDatabase) InsertResult(result *models.Result) error {
-	//resultsCollection := db.Session.DB(config.MongoDbName).C("results")
-	//err := resultsCollection.Insert(&result)
-	return nil
+	_, err := db.ResultsCollection.InsertOne(context.Background(), result)
+	return err
 }
 
-// TODO
 func (db ElectionDatabase) FindAllResults() ([]models.Result, error) {
-	//resultsCollection := db.Session.DB(config.MongoDbName).C("results")
 	var results []models.Result
-	//err := resultsCollection.Find(nil).All(&results)
-	return results, nil
+
+	cursor, err := db.ResultsCollection.Find(context.Background(), bson.M{})
+	if err != nil {
+		return results, err
+	}
+
+	err = cursor.All(context.Background(), &results)
+	return results, err
 }
 
-// TODO
 func (db ElectionDatabase) ClearResults() error {
-	//resultsCollection := db.Session.DB(config.MongoDbName).C("results")
-	//_, err := resultsCollection.RemoveAll(nil)
-	return nil
+	err := db.ResultsCollection.Drop(context.Background())
+	return err
 }

--- a/models/result.go
+++ b/models/result.go
@@ -1,63 +1,19 @@
 package models
 
-import "strconv"
-
 type (
 	// Basic structure of a result as stored in the database.
+	CandidateResult struct {
+		Name        string `json:"name"`
+		Roll        string `json:"roll"`
+		Preference1 int32  `json:"preference1"`
+		Preference2 int32  `json:"preference2"`
+		Preference3 int32  `json:"preference3"`
+		Status      string `json:"status"`
+	}
+
 	Result struct {
-		PostID      string `json:"postid"`
-		Candidate   string `json:"candidate"`
-		Preference1 string `json:"preference1"`
-		Preference2 string `json:"preference2"`
-		Preference3 string `json:"preference3"`
+		ID         string            `json:"postId"`
+		Name       string            `json:"postName"`
+		Candidates []CandidateResult `json:"candidate"`
 	}
-
-	NumericResult struct {
-		PostID      int
-		Candidate   string
-		Preference1 int
-		Preference2 int
-		Preference3 int
-	}
-
-	ResultSorter []NumericResult
 )
-
-func (result *Result) ToNumericResult() NumericResult {
-	postId, _ := strconv.Atoi(result.PostID)
-	p1, _ := strconv.Atoi(result.Preference1)
-	p2, _ := strconv.Atoi(result.Preference2)
-	p3, _ := strconv.Atoi(result.Preference3)
-	return NumericResult{
-		PostID:      postId,
-		Candidate:   result.Candidate,
-		Preference1: p1,
-		Preference2: p2,
-		Preference3: p3,
-	}
-}
-
-func (a ResultSorter) Len() int {
-	return len(a)
-}
-
-func (a ResultSorter) Swap(i, j int) {
-	a[i], a[j] = a[j], a[i]
-}
-
-func (a ResultSorter) Less(i, j int) bool {
-	if a[i].PostID != a[j].PostID {
-		return a[i].PostID < a[j].PostID
-	}
-
-	if a[i].Preference1 > a[j].Preference1 {
-		return true
-	} else if a[i].Preference1 == a[j].Preference1 {
-		if a[i].Preference2 > a[j].Preference2 {
-			return true
-		} else if a[i].Preference2 == a[j].Preference2 {
-			return a[i].Preference3 > a[j].Preference3
-		}
-	}
-	return false
-}

--- a/models/single-vote-result.go
+++ b/models/single-vote-result.go
@@ -1,6 +1,6 @@
 package models
 
-type CandidateResult struct {
+type SingleVoteCandidateResult struct {
 	Name   string `json:"name"`
 	Roll   string `json:"roll"`
 	Count  int32  `json:"count"`
@@ -8,7 +8,7 @@ type CandidateResult struct {
 }
 
 type SingleVoteResult struct {
-	ID         string            `json:"postId"`
-	Name       string            `json:"postName"`
-	Candidates []CandidateResult `json:"candidates"`
+	ID         string                      `json:"postId"`
+	Name       string                      `json:"postName"`
+	Candidates []SingleVoteCandidateResult `json:"candidates"`
 }

--- a/models/vote.go
+++ b/models/vote.go
@@ -31,10 +31,17 @@ type (
 		VoteData     string `json:"VoteData"`
 	}
 
-	UsedBallotID struct {
+	UsedSingleVoteBallotID struct {
 		BallotString string
 		Roll         string
 		Name         string
+	}
+
+	UsedBallotID struct {
+		BallotString string `json:"ballotString"`
+		Preference1  string `json:"preference1"`
+		Preference2  string `json:"preference2"`
+		Preference3  string `json:"preference3"`
 	}
 )
 

--- a/router/router.go
+++ b/router/router.go
@@ -26,7 +26,8 @@ func SetUpRoutes(r *gin.Engine) {
 		election.GET("/getCandidateInfo/:username", controllers.GetCandidateInfo)
 		election.GET("/getElectionState", controllers.GetElectionState)
 		election.POST("/submitVote", controllers.SubmitVote)
-		election.GET("/results", controllers.GetSingleVoteResults)
+		election.GET("/singleVoteResults", controllers.GetSingleVoteResults)
+		election.GET("/results", controllers.GetResults)
 	}
 
 	ceo := r.Group("/ceo")

--- a/router/router.go
+++ b/router/router.go
@@ -37,7 +37,7 @@ func SetUpRoutes(r *gin.Engine) {
 		ceo.GET("/fetchVotes", controllers.FetchVotes)
 		ceo.GET("/fetchCandidates", controllers.FetchCandidates)
 		ceo.GET("/resultProgress", controllers.ResultProgress)
-		ceo.GET("/getResult", controllers.GetResult)
+		ceo.POST("/submitSingleVoteResults", controllers.SubmitSingleVoteResults)
 		ceo.POST("/submitResults", controllers.SubmitSingleVoteResults)
 		ceo.POST("/prepareForNextRound", controllers.PrepareForNextRound)
 	}

--- a/utils/ballot-ids.go
+++ b/utils/ballot-ids.go
@@ -10,7 +10,7 @@ import (
 	"github.com/dryairship/online-election-manager/models"
 )
 
-func ExportBallotIdsToFile(ballotIds []models.UsedBallotID, fileName string) error {
+func ExportSingleVoteBallotIdsToFile(ballotIds []models.UsedSingleVoteBallotID, fileName string) error {
 	path := fmt.Sprintf("%s/%s", config.BallotIDsPath, fileName)
 	file, err := os.Create(path)
 	if err != nil {
@@ -22,6 +22,29 @@ func ExportBallotIdsToFile(ballotIds []models.UsedBallotID, fileName string) err
 
 	for _, ballotId := range ballotIds {
 		_, err = w.WriteString(fmt.Sprintf("%s - %s - %s\n", ballotId.BallotString, ballotId.Roll, ballotId.Name))
+		if err != nil {
+			return err
+		}
+	}
+
+	w.Flush()
+	log.Println("[INFO] Ballot IDs saved in: ", fileName)
+
+	return nil
+}
+
+func ExportBallotIdsToFile(ballotIds []models.UsedBallotID, fileName string) error {
+	path := fmt.Sprintf("%s/%s", config.BallotIDsPath, fileName)
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	w := bufio.NewWriter(file)
+
+	for _, ballotId := range ballotIds {
+		_, err = w.WriteString(fmt.Sprintf("%s - %s, %s, %s\n", ballotId.BallotString, ballotId.Preference1, ballotId.Preference2, ballotId.Preference3))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
 - Use `singleVote` prefix for structs/functions that are not for single preference votes
 - Add model and db support for generic preference votes
 - Create separate endpoints for submitting and fetching single vote results and generic vote results.